### PR TITLE
Add support for servername field

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ _Note_: The web interface of phpMyAdmin may change in the future and break this 
       -e EXCLUDE_DBS, --exclude-dbs EXCLUDE_DBS
                             comma-separated list of database names to exclude from
                             the dump
+      -s SERVER_NAME, --server-name SERVER_NAME
+                            mysql server hostname to supply if enabled as field on login page
       --compression {none,zip,gzip}
                             compression method for the output file - must be
                             supported by the server (default: none)

--- a/phpmyadmin_sql_backup.py
+++ b/phpmyadmin_sql_backup.py
@@ -40,7 +40,7 @@ DEFAULT_PREFIX_FORMAT = r'%Y-%m-%d--%H-%M-%S-UTC_'
 
 def download_sql_backup(url, user, password, dry_run=False, overwrite_existing=False, prepend_date=True, basename=None,
                         output_directory=os.getcwd(), exclude_dbs=None, compression='none', prefix_format=None,
-                        timeout=60, http_auth=None, **kwargs):
+                        timeout=60, http_auth=None, server_name=None, **kwargs):
     prefix_format = prefix_format or DEFAULT_PREFIX_FORMAT
     exclude_dbs = exclude_dbs.split(',') or []
     encoding = '' if compression == 'gzip' else 'gzip'
@@ -52,6 +52,8 @@ def download_sql_backup(url, user, password, dry_run=False, overwrite_existing=F
 
     g.doc.set_input_by_id('input_username', user)
     g.doc.set_input_by_id('input_password', password)
+    if server_name:
+        g.doc.set_input_by_id('input_servername', server_name)
     g.submit()
 
     try:
@@ -113,6 +115,7 @@ if __name__ == '__main__':
         help='prepend current UTC date & time to the filename; see the --prefix-format option for custom formatting')
     parser.add_argument('-e', '--exclude-dbs', default='',
         help='comma-separated list of database names to exclude from the dump')
+    parser.add_argument('-s', '--server-name', default=None, help='mysql server hostname to supply if enabled as field on login page')
     parser.add_argument('--compression', default='none', choices=['none', 'zip', 'gzip'],
         help='compression method for the output file - must be supported by the server (default: %(default)s)')
     parser.add_argument('--basename', default=None,

--- a/phpmyadmin_sql_backup.py
+++ b/phpmyadmin_sql_backup.py
@@ -52,7 +52,7 @@ def download_sql_backup(url, user, password, dry_run=False, overwrite_existing=F
 
     g.doc.set_input_by_id('input_username', user)
     g.doc.set_input_by_id('input_password', password)
-    g.doc.submit()
+    g.submit()
 
     try:
         g.doc.text_assert('server_export.php')
@@ -67,13 +67,13 @@ def download_sql_backup(url, user, password, dry_run=False, overwrite_existing=F
         print('Warning: no databases to dump (databases available: "{}")'.format('", "'.join(dbs_available)),
             file=sys.stderr)
 
-    file_response = g.doc.submit(
+    file_response = g.submit(
         extra_post=[('db_select[]', db_name) for db_name in dbs_to_dump] + [('compression', compression)])
 
-    re_match = CONTENT_DISPOSITION_FILENAME_RE.match(g.response.headers['Content-Disposition'])
+    re_match = CONTENT_DISPOSITION_FILENAME_RE.match(g.doc.headers['Content-Disposition'])
     if not re_match:
         raise ValueError(
-            'Could not determine SQL backup filename from {}'.format(g.response.headers['Content-Disposition']))
+            'Could not determine SQL backup filename from {}'.format(g.doc.headers['Content-Disposition']))
 
     content_filename = re_match.group('filename')
     filename = content_filename if basename is None else basename + os.path.splitext(content_filename)[1]


### PR DESCRIPTION
This adds support for providing a mysql servername on the phpMyAdmin login page.  This is necessary for using this tool with phpMyAdmin servers that are configured to prompt for the mysql server hostname along with credentials at login.

Also, I had to update the calls to the Grab library to avoid deprecated functions.  Without this, the sql file would not save for me using latest Grab library (as pulled by pip install grab) and python 3.4.9.

Note that I did not bump the version value since I wasn't sure what new value you'd want to use.  Let me know if you'd like me to include a specific new version value in the PR.